### PR TITLE
Add mobile dropdown navigation for tablets

### DIFF
--- a/components/Nav.jsx
+++ b/components/Nav.jsx
@@ -3,12 +3,15 @@
 import Link from "next/link";
 import Image from "next/image";
 import { usePathname } from "next/navigation";
+import { useState } from "react";
 
 export default function Nav() {
   const p = usePathname();
+  const [open, setOpen] = useState(false);
   const tab = (href, label) => (
     <Link
       href={href}
+      onClick={() => setOpen(false)}
       className={
         "px-4 py-2 rounded-full text-sm bubble transition " +
         (p === href ? "bubble-active" : "")
@@ -38,12 +41,45 @@ export default function Nav() {
           {tab("/shop", "Shop Prints")}
         </nav>
 
-        <Link
-          href="/design"
-          className="ml-auto rounded-xl bubble px-3 py-1.5 text-sm hover:brightness-110"
-        >
-          Get a Quote
-        </Link>
+        <div className="ml-auto flex items-center gap-2">
+          <div className="relative md:hidden">
+            <button
+              type="button"
+              className="rounded-md p-2 hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/20"
+              onClick={() => setOpen(!open)}
+            >
+              <span className="sr-only">Open main menu</span>
+              <svg
+                className="h-6 w-6"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M3.75 5.75h16.5M3.75 12h16.5M3.75 18.25h16.5"
+                />
+              </svg>
+            </button>
+            {open && (
+              <div className="absolute right-0 mt-2 w-48 rounded-md bg-header/95 backdrop-blur shadow-lg ring-1 ring-black/5 p-2 flex flex-col gap-1">
+                {tab("/", "Home")}
+                {tab("/design", "Design Work")}
+                {tab("/shop", "Shop Prints")}
+              </div>
+            )}
+          </div>
+
+          <Link
+            href="/design"
+            className="rounded-xl bubble px-3 py-1.5 text-sm hover:brightness-110"
+          >
+            Get a Quote
+          </Link>
+        </div>
       </div>
     </header>
   );


### PR DESCRIPTION
## Summary
- add hamburger menu for tablet/mobile views
- close menu on navigation

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a506a9ba0c8331867edb8b61b07602