### PR TITLE
Add design request thank-you page

### DIFF
--- a/app/design/page.jsx
+++ b/app/design/page.jsx
@@ -56,7 +56,7 @@ export default function DesignPage() {
           const prev = JSON.parse(localStorage.getItem("dixon3d_requests") || "[]");
           localStorage.setItem("dixon3d_requests", JSON.stringify([payload, ...prev]));
           e.currentTarget.reset();
-          document.getElementById("thanks").classList.remove("hidden-soft");
+          window.location.href = "/design/thank-you";
         }}>
           <div className="grid sm:grid-cols-2 gap-4">
             <label className="block">
@@ -109,11 +109,6 @@ export default function DesignPage() {
             <button className="rounded-xl bubble px-5 py-2.5 text-sm font-semibold">Submit</button>
           </div>
         </form>
-
-        <div id="thanks" className="hidden-soft max-w-2xl mx-auto text-center space-y-4 mt-6">
-          <h2 className="text-2xl font-bold">Thanks! 🎉</h2>
-          <p className="text-slate-200">Saved in your browser. Hook up email/API later.</p>
-        </div>
       </section>
     </div>
   );

--- a/app/design/thank-you/page.jsx
+++ b/app/design/thank-you/page.jsx
@@ -1,0 +1,10 @@
+export default function DesignThankYou() {
+  return (
+    <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 pb-24 pt-10 space-y-6 text-center">
+      <h1 className="text-3xl font-bold">Thanks! 🎉</h1>
+      <p className="text-slate-200">We'll review your design request and get back to you soon.</p>
+      <a href="/design" className="underline">Back to design page</a>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add hidden `/design/thank-you` page acknowledging design requests
- redirect design submission form to new thank-you page

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a50b7ca1788331a106ecc78bcb382c