### PR TITLE
Fix PayPal checkout errors and unify shop styling

### DIFF
--- a/app/api/paypal/capture/route.js
+++ b/app/api/paypal/capture/route.js
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+
+const base = (env) =>
+  env === "live" ? "https://api-m.paypal.com" : "https://api-m.sandbox.paypal.com";
+
+async function getAccessToken() {
+  const id = process.env.PAYPAL_CLIENT_ID;
+  const secret = process.env.PAYPAL_SECRET;
+  const creds = Buffer.from(`${id}:${secret}`).toString("base64");
+  const res = await fetch(`${base(process.env.PAYPAL_ENV)}/v1/oauth2/token`, {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${creds}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: "grant_type=client_credentials",
+  });
+  if (!res.ok) throw new Error("PayPal auth failed");
+  const json = await res.json();
+  return json.access_token;
+}
+
+export async function GET(req) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const orderId = searchParams.get("token") || searchParams.get("order_id");
+    if (!orderId) {
+      return NextResponse.json({ error: "Missing order id" }, { status: 400 });
+    }
+
+    const token = await getAccessToken();
+    const res = await fetch(
+      `${base(process.env.PAYPAL_ENV)}/v2/checkout/orders/${orderId}/capture`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: "{}",
+      }
+    );
+    const capture = await res.json();
+
+    return NextResponse.json(capture, { status: res.ok ? 200 : 500 });
+  } catch (e) {
+    return NextResponse.json({ error: String(e) }, { status: 500 });
+  }
+}

--- a/app/api/paypal/create/route.js
+++ b/app/api/paypal/create/route.js
@@ -1,0 +1,63 @@
+import { NextResponse } from "next/server";
+
+const base = (env) =>
+  env === "live" ? "https://api-m.paypal.com" : "https://api-m.sandbox.paypal.com";
+
+async function getAccessToken() {
+  const id = process.env.PAYPAL_CLIENT_ID;
+  const secret = process.env.PAYPAL_SECRET;
+  const creds = Buffer.from(`${id}:${secret}`).toString("base64");
+  const res = await fetch(`${base(process.env.PAYPAL_ENV)}/v1/oauth2/token`, {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${creds}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: "grant_type=client_credentials",
+  });
+  if (!res.ok) {
+    const msg = await res.text();
+    throw new Error(`PayPal auth failed: ${msg}`);
+  }
+  const json = await res.json();
+  return json.access_token;
+}
+
+export async function POST(req) {
+  try {
+    const body = await req.json();
+    const amount = String(body.amount || "10.00");
+    const currency = String(body.currency || "USD");
+
+    const token = await getAccessToken();
+    const site =
+      process.env.NEXT_PUBLIC_SITE_URL ||
+      process.env.URL ||
+      process.env.DEPLOY_URL ||
+      "http://localhost:3000";
+
+    const payload = {
+      intent: "CAPTURE",
+      purchase_units: [{ amount: { currency_code: currency, value: amount } }],
+      application_context: {
+        return_url: `${site}/thank-you`,
+        cancel_url: `${site}/shop`,
+        shipping_preference: "NO_SHIPPING",
+        user_action: "PAY_NOW",
+      },
+    };
+
+    const res = await fetch(`${base(process.env.PAYPAL_ENV)}/v2/checkout/orders`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+
+    const order = await res.json();
+    const approve = (order.links || []).find((l) => l.rel === "approve")?.href;
+
+    return NextResponse.json({ id: order.id, approve }, { status: res.ok ? 200 : 500 });
+  } catch (e) {
+    return NextResponse.json({ error: String(e) }, { status: 500 });
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -88,5 +88,22 @@
     inset 0 1px 0 rgba(255,255,255,.35);
 }
 
+/* Dark theme inputs (Shop qty boxes etc) */
+.input-dark{
+  background-image: linear-gradient(180deg, rgba(255,255,255,.12), rgba(255,255,255,.06));
+  border: 1px solid rgba(255,255,255,.22);
+  color:#f1f5f9;
+  box-shadow:
+    inset 0 1px 0 rgba(255,255,255,.08),
+    0 1px 1px rgba(0,0,0,.15);
+}
+.input-dark:focus{
+  outline: none;
+  border-color: rgba(59,130,246,.45);
+  box-shadow:
+    0 0 0 3px rgba(59,130,246,.30),
+    inset 0 1px 0 rgba(255,255,255,.08);
+}
+
 /* Utility */
 .hidden-soft{display:none !important;}

--- a/app/shop/page.jsx
+++ b/app/shop/page.jsx
@@ -48,7 +48,7 @@ export default function ShopPage() {
     });
     const data = await res.json();
     if (data?.approve) window.location.href = data.approve;
-    else alert("Could not start PayPal checkout.");
+    else alert(data?.error || "Could not start PayPal checkout.");
   }
 
   return (
@@ -80,7 +80,7 @@ export default function ShopPage() {
               <p className="text-xs text-slate-400 mt-1">{p.material} • {p.category}</p>
               <div className="mt-3 flex items-center gap-2">
                 <input type="number" min="1" defaultValue="1" id={`qty-${p.id}`}
-                       className="w-16 rounded-lg input-soft px-2 py-1 text-sm"/>
+                       className="w-16 rounded-lg input-dark px-2 py-1 text-sm"/>
                 <button onClick={() => add(p.id, parseInt(document.getElementById(`qty-${p.id}`).value || "1", 10))}
                         className="rounded-lg bubble px-3 py-1.5 text-xs font-semibold hover:brightness-110">
                   Add
@@ -91,7 +91,7 @@ export default function ShopPage() {
         ))}
       </div>
 
-      <section className="mt-10 rounded-2xl bg-white text-slate-900 p-4">
+      <section className="mt-10 rounded-2xl panel text-slate-100 p-4">
         <div className="flex items-center justify-between">
           <h3 className="text-lg font-semibold">Your Cart</h3>
           <div className="text-lg font-semibold">{money(subtotal)}</div>
@@ -107,7 +107,7 @@ export default function ShopPage() {
                 <div className="mt-2 flex items-center gap-2">
                   <input type="number" min="1" value={it.qty}
                          onChange={(e)=>updateQty(it.key, parseInt(e.target.value||"1",10))}
-                         className="w-16 rounded-lg input-soft px-2 py-1 text-sm"/>
+                         className="w-16 rounded-lg input-dark px-2 py-1 text-sm"/>
                   <button onClick={()=>removeItem(it.key)} className="text-xs text-slate-600 hover:text-black">Remove</button>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- add Next.js API routes for PayPal order creation and capture to support local checkout
- improve checkout error messaging and cart styling
- send JSON body with proper content type when capturing PayPal orders to avoid unsupported media type errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a52176fcac83318bf04767029288cc