### PR TITLE
feat: select PayPal credentials based on environment

### DIFF
--- a/app/api/paypal/capture/route.js
+++ b/app/api/paypal/capture/route.js
@@ -4,8 +4,15 @@ const base = (env) =>
   env === "live" ? "https://api-m.paypal.com" : "https://api-m.sandbox.paypal.com";
 
 async function getAccessToken() {
-  const id = process.env.PAYPAL_CLIENT_ID;
-  const secret = process.env.PAYPAL_SECRET;
+  const env = process.env.PAYPAL_ENV;
+  const id =
+    env === "live"
+      ? process.env.PAYPAL_CLIENT_ID
+      : process.env.PAYPAL_SANDBOX_CLIENT_ID;
+  const secret =
+    env === "live"
+      ? process.env.PAYPAL_SECRET
+      : process.env.PAYPAL_SANDBOX_CLIENT_SECRET;
   const creds = Buffer.from(`${id}:${secret}`).toString("base64");
   const res = await fetch(`${base(process.env.PAYPAL_ENV)}/v1/oauth2/token`, {
     method: "POST",

--- a/app/api/paypal/create/route.js
+++ b/app/api/paypal/create/route.js
@@ -4,8 +4,15 @@ const base = (env) =>
   env === "live" ? "https://api-m.paypal.com" : "https://api-m.sandbox.paypal.com";
 
 async function getAccessToken() {
-  const id = process.env.PAYPAL_CLIENT_ID;
-  const secret = process.env.PAYPAL_SECRET;
+  const env = process.env.PAYPAL_ENV;
+  const id =
+    env === "live"
+      ? process.env.PAYPAL_CLIENT_ID
+      : process.env.PAYPAL_SANDBOX_CLIENT_ID;
+  const secret =
+    env === "live"
+      ? process.env.PAYPAL_SECRET
+      : process.env.PAYPAL_SANDBOX_CLIENT_SECRET;
   const creds = Buffer.from(`${id}:${secret}`).toString("base64");
   const res = await fetch(`${base(process.env.PAYPAL_ENV)}/v1/oauth2/token`, {
     method: "POST",

--- a/netlify/functions/paypal-capture-order.js
+++ b/netlify/functions/paypal-capture-order.js
@@ -2,8 +2,15 @@ const base = (env) =>
   env === "live" ? "https://api-m.paypal.com" : "https://api-m.sandbox.paypal.com";
 
 async function getAccessToken() {
-  const id = process.env.PAYPAL_CLIENT_ID;
-  const secret = process.env.PAYPAL_SECRET;
+  const env = process.env.PAYPAL_ENV;
+  const id =
+    env === "live"
+      ? process.env.PAYPAL_CLIENT_ID
+      : process.env.PAYPAL_SANDBOX_CLIENT_ID;
+  const secret =
+    env === "live"
+      ? process.env.PAYPAL_SECRET
+      : process.env.PAYPAL_SANDBOX_CLIENT_SECRET;
   const creds = Buffer.from(`${id}:${secret}`).toString("base64");
   const res = await fetch(`${base(process.env.PAYPAL_ENV)}/v1/oauth2/token`, {
     method: "POST",

--- a/netlify/functions/paypal-create-order.js
+++ b/netlify/functions/paypal-create-order.js
@@ -2,8 +2,15 @@ const base = (env) =>
   env === "live" ? "https://api-m.paypal.com" : "https://api-m.sandbox.paypal.com";
 
 async function getAccessToken() {
-  const id = process.env.PAYPAL_CLIENT_ID;
-  const secret = process.env.PAYPAL_SECRET;
+  const env = process.env.PAYPAL_ENV;
+  const id =
+    env === "live"
+      ? process.env.PAYPAL_CLIENT_ID
+      : process.env.PAYPAL_SANDBOX_CLIENT_ID;
+  const secret =
+    env === "live"
+      ? process.env.PAYPAL_SECRET
+      : process.env.PAYPAL_SANDBOX_CLIENT_SECRET;
   const creds = Buffer.from(`${id}:${secret}`).toString("base64");
   const res = await fetch(`${base(process.env.PAYPAL_ENV)}/v1/oauth2/token`, {
     method: "POST",


### PR DESCRIPTION
## Summary
- choose PayPal client ID/secret depending on PAYPAL_ENV for Netlify functions and Next.js routes

## Testing
- `npm test` *(fails: Missing script: "test" )*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a529da99008331b00f0aee83adbea8