### PR TITLE
Fix PayPal auth by falling back to available credentials

### DIFF
--- a/app/api/paypal/capture/route.js
+++ b/app/api/paypal/capture/route.js
@@ -8,11 +8,17 @@ async function getAccessToken() {
   const id =
     env === "live"
       ? process.env.PAYPAL_CLIENT_ID
-      : process.env.PAYPAL_SANDBOX_CLIENT_ID;
+      : process.env.PAYPAL_SANDBOX_CLIENT_ID || process.env.PAYPAL_CLIENT_ID;
   const secret =
     env === "live"
-      ? process.env.PAYPAL_SECRET
-      : process.env.PAYPAL_SANDBOX_CLIENT_SECRET;
+      ? process.env.PAYPAL_CLIENT_SECRET || process.env.PAYPAL_SECRET
+      :
+          process.env.PAYPAL_SANDBOX_CLIENT_SECRET ||
+          process.env.PAYPAL_CLIENT_SECRET ||
+          process.env.PAYPAL_SECRET;
+  if (!id || !secret) {
+    throw new Error("Missing PayPal credentials");
+  }
   const creds = Buffer.from(`${id}:${secret}`).toString("base64");
   const res = await fetch(`${base(process.env.PAYPAL_ENV)}/v1/oauth2/token`, {
     method: "POST",

--- a/app/api/paypal/create/route.js
+++ b/app/api/paypal/create/route.js
@@ -8,11 +8,17 @@ async function getAccessToken() {
   const id =
     env === "live"
       ? process.env.PAYPAL_CLIENT_ID
-      : process.env.PAYPAL_SANDBOX_CLIENT_ID;
+      : process.env.PAYPAL_SANDBOX_CLIENT_ID || process.env.PAYPAL_CLIENT_ID;
   const secret =
     env === "live"
-      ? process.env.PAYPAL_SECRET
-      : process.env.PAYPAL_SANDBOX_CLIENT_SECRET;
+      ? process.env.PAYPAL_CLIENT_SECRET || process.env.PAYPAL_SECRET
+      :
+          process.env.PAYPAL_SANDBOX_CLIENT_SECRET ||
+          process.env.PAYPAL_CLIENT_SECRET ||
+          process.env.PAYPAL_SECRET;
+  if (!id || !secret) {
+    throw new Error("Missing PayPal credentials");
+  }
   const creds = Buffer.from(`${id}:${secret}`).toString("base64");
   const res = await fetch(`${base(process.env.PAYPAL_ENV)}/v1/oauth2/token`, {
     method: "POST",

--- a/netlify/functions/paypal-capture-order.js
+++ b/netlify/functions/paypal-capture-order.js
@@ -6,11 +6,17 @@ async function getAccessToken() {
   const id =
     env === "live"
       ? process.env.PAYPAL_CLIENT_ID
-      : process.env.PAYPAL_SANDBOX_CLIENT_ID;
+      : process.env.PAYPAL_SANDBOX_CLIENT_ID || process.env.PAYPAL_CLIENT_ID;
   const secret =
     env === "live"
-      ? process.env.PAYPAL_SECRET
-      : process.env.PAYPAL_SANDBOX_CLIENT_SECRET;
+      ? process.env.PAYPAL_CLIENT_SECRET || process.env.PAYPAL_SECRET
+      :
+          process.env.PAYPAL_SANDBOX_CLIENT_SECRET ||
+          process.env.PAYPAL_CLIENT_SECRET ||
+          process.env.PAYPAL_SECRET;
+  if (!id || !secret) {
+    throw new Error("Missing PayPal credentials");
+  }
   const creds = Buffer.from(`${id}:${secret}`).toString("base64");
   const res = await fetch(`${base(process.env.PAYPAL_ENV)}/v1/oauth2/token`, {
     method: "POST",

--- a/netlify/functions/paypal-create-order.js
+++ b/netlify/functions/paypal-create-order.js
@@ -6,11 +6,17 @@ async function getAccessToken() {
   const id =
     env === "live"
       ? process.env.PAYPAL_CLIENT_ID
-      : process.env.PAYPAL_SANDBOX_CLIENT_ID;
+      : process.env.PAYPAL_SANDBOX_CLIENT_ID || process.env.PAYPAL_CLIENT_ID;
   const secret =
     env === "live"
-      ? process.env.PAYPAL_SECRET
-      : process.env.PAYPAL_SANDBOX_CLIENT_SECRET;
+      ? process.env.PAYPAL_CLIENT_SECRET || process.env.PAYPAL_SECRET
+      :
+          process.env.PAYPAL_SANDBOX_CLIENT_SECRET ||
+          process.env.PAYPAL_CLIENT_SECRET ||
+          process.env.PAYPAL_SECRET;
+  if (!id || !secret) {
+    throw new Error("Missing PayPal credentials");
+  }
   const creds = Buffer.from(`${id}:${secret}`).toString("base64");
   const res = await fetch(`${base(process.env.PAYPAL_ENV)}/v1/oauth2/token`, {
     method: "POST",


### PR DESCRIPTION
## Summary
- ensure PayPal API uses provided client ID and secret even if sandbox-specific vars are missing
- throw explicit error when credentials are missing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a52bb8c1308331911c60efedb474b4