### PR TITLE
Force PayPal sandbox usage to avoid auth failures

### DIFF
--- a/app/api/paypal/capture/route.js
+++ b/app/api/paypal/capture/route.js
@@ -1,26 +1,19 @@
 import { NextResponse } from "next/server";
 
-const base = (env) =>
-  env === "live" ? "https://api-m.paypal.com" : "https://api-m.sandbox.paypal.com";
+const BASE_URL = "https://api-m.sandbox.paypal.com";
 
 async function getAccessToken() {
-  const env = process.env.PAYPAL_ENV;
   const id =
-    env === "live"
-      ? process.env.PAYPAL_CLIENT_ID
-      : process.env.PAYPAL_SANDBOX_CLIENT_ID || process.env.PAYPAL_CLIENT_ID;
+    process.env.PAYPAL_SANDBOX_CLIENT_ID || process.env.PAYPAL_CLIENT_ID;
   const secret =
-    env === "live"
-      ? process.env.PAYPAL_CLIENT_SECRET || process.env.PAYPAL_SECRET
-      :
-          process.env.PAYPAL_SANDBOX_CLIENT_SECRET ||
-          process.env.PAYPAL_CLIENT_SECRET ||
-          process.env.PAYPAL_SECRET;
+    process.env.PAYPAL_SANDBOX_CLIENT_SECRET ||
+    process.env.PAYPAL_CLIENT_SECRET ||
+    process.env.PAYPAL_SECRET;
   if (!id || !secret) {
     throw new Error("Missing PayPal credentials");
   }
   const creds = Buffer.from(`${id}:${secret}`).toString("base64");
-  const res = await fetch(`${base(process.env.PAYPAL_ENV)}/v1/oauth2/token`, {
+  const res = await fetch(`${BASE_URL}/v1/oauth2/token`, {
     method: "POST",
     headers: {
       Authorization: `Basic ${creds}`,
@@ -43,7 +36,7 @@ export async function GET(req) {
 
     const token = await getAccessToken();
     const res = await fetch(
-      `${base(process.env.PAYPAL_ENV)}/v2/checkout/orders/${orderId}/capture`,
+      `${BASE_URL}/v2/checkout/orders/${orderId}/capture`,
       { method: "POST", headers: { Authorization: `Bearer ${token}` } }
     );
     const capture = await res.json();

--- a/app/api/paypal/create/route.js
+++ b/app/api/paypal/create/route.js
@@ -1,26 +1,19 @@
 import { NextResponse } from "next/server";
 
-const base = (env) =>
-  env === "live" ? "https://api-m.paypal.com" : "https://api-m.sandbox.paypal.com";
+const BASE_URL = "https://api-m.sandbox.paypal.com";
 
 async function getAccessToken() {
-  const env = process.env.PAYPAL_ENV;
   const id =
-    env === "live"
-      ? process.env.PAYPAL_CLIENT_ID
-      : process.env.PAYPAL_SANDBOX_CLIENT_ID || process.env.PAYPAL_CLIENT_ID;
+    process.env.PAYPAL_SANDBOX_CLIENT_ID || process.env.PAYPAL_CLIENT_ID;
   const secret =
-    env === "live"
-      ? process.env.PAYPAL_CLIENT_SECRET || process.env.PAYPAL_SECRET
-      :
-          process.env.PAYPAL_SANDBOX_CLIENT_SECRET ||
-          process.env.PAYPAL_CLIENT_SECRET ||
-          process.env.PAYPAL_SECRET;
+    process.env.PAYPAL_SANDBOX_CLIENT_SECRET ||
+    process.env.PAYPAL_CLIENT_SECRET ||
+    process.env.PAYPAL_SECRET;
   if (!id || !secret) {
     throw new Error("Missing PayPal credentials");
   }
   const creds = Buffer.from(`${id}:${secret}`).toString("base64");
-  const res = await fetch(`${base(process.env.PAYPAL_ENV)}/v1/oauth2/token`, {
+  const res = await fetch(`${BASE_URL}/v1/oauth2/token`, {
     method: "POST",
     headers: {
       Authorization: `Basic ${creds}`,
@@ -60,7 +53,7 @@ export async function POST(req) {
       },
     };
 
-    const res = await fetch(`${base(process.env.PAYPAL_ENV)}/v2/checkout/orders`, {
+    const res = await fetch(`${BASE_URL}/v2/checkout/orders`, {
       method: "POST",
       headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
       body: JSON.stringify(payload),

--- a/netlify/functions/paypal-capture-order.js
+++ b/netlify/functions/paypal-capture-order.js
@@ -1,24 +1,17 @@
-const base = (env) =>
-  env === "live" ? "https://api-m.paypal.com" : "https://api-m.sandbox.paypal.com";
+const BASE_URL = "https://api-m.sandbox.paypal.com";
 
 async function getAccessToken() {
-  const env = process.env.PAYPAL_ENV;
   const id =
-    env === "live"
-      ? process.env.PAYPAL_CLIENT_ID
-      : process.env.PAYPAL_SANDBOX_CLIENT_ID || process.env.PAYPAL_CLIENT_ID;
+    process.env.PAYPAL_SANDBOX_CLIENT_ID || process.env.PAYPAL_CLIENT_ID;
   const secret =
-    env === "live"
-      ? process.env.PAYPAL_CLIENT_SECRET || process.env.PAYPAL_SECRET
-      :
-          process.env.PAYPAL_SANDBOX_CLIENT_SECRET ||
-          process.env.PAYPAL_CLIENT_SECRET ||
-          process.env.PAYPAL_SECRET;
+    process.env.PAYPAL_SANDBOX_CLIENT_SECRET ||
+    process.env.PAYPAL_CLIENT_SECRET ||
+    process.env.PAYPAL_SECRET;
   if (!id || !secret) {
     throw new Error("Missing PayPal credentials");
   }
   const creds = Buffer.from(`${id}:${secret}`).toString("base64");
-  const res = await fetch(`${base(process.env.PAYPAL_ENV)}/v1/oauth2/token`, {
+  const res = await fetch(`${BASE_URL}/v1/oauth2/token`, {
     method: "POST",
     headers: {
       Authorization: `Basic ${creds}`,
@@ -41,7 +34,7 @@ exports.handler = async (event) => {
 
     const token = await getAccessToken();
     const res = await fetch(
-      `${base(process.env.PAYPAL_ENV)}/v2/checkout/orders/${orderId}/capture`,
+      `${BASE_URL}/v2/checkout/orders/${orderId}/capture`,
       { method: "POST", headers: { Authorization: `Bearer ${token}` } }
     );
     const capture = await res.json();

--- a/netlify/functions/paypal-create-order.js
+++ b/netlify/functions/paypal-create-order.js
@@ -1,24 +1,17 @@
-const base = (env) =>
-  env === "live" ? "https://api-m.paypal.com" : "https://api-m.sandbox.paypal.com";
+const BASE_URL = "https://api-m.sandbox.paypal.com";
 
 async function getAccessToken() {
-  const env = process.env.PAYPAL_ENV;
   const id =
-    env === "live"
-      ? process.env.PAYPAL_CLIENT_ID
-      : process.env.PAYPAL_SANDBOX_CLIENT_ID || process.env.PAYPAL_CLIENT_ID;
+    process.env.PAYPAL_SANDBOX_CLIENT_ID || process.env.PAYPAL_CLIENT_ID;
   const secret =
-    env === "live"
-      ? process.env.PAYPAL_CLIENT_SECRET || process.env.PAYPAL_SECRET
-      :
-          process.env.PAYPAL_SANDBOX_CLIENT_SECRET ||
-          process.env.PAYPAL_CLIENT_SECRET ||
-          process.env.PAYPAL_SECRET;
+    process.env.PAYPAL_SANDBOX_CLIENT_SECRET ||
+    process.env.PAYPAL_CLIENT_SECRET ||
+    process.env.PAYPAL_SECRET;
   if (!id || !secret) {
     throw new Error("Missing PayPal credentials");
   }
   const creds = Buffer.from(`${id}:${secret}`).toString("base64");
-  const res = await fetch(`${base(process.env.PAYPAL_ENV)}/v1/oauth2/token`, {
+  const res = await fetch(`${BASE_URL}/v1/oauth2/token`, {
     method: "POST",
     headers: {
       Authorization: `Basic ${creds}`,
@@ -55,7 +48,7 @@ exports.handler = async (event, context) => {
       }
     };
 
-    const res = await fetch(`${base(process.env.PAYPAL_ENV)}/v2/checkout/orders`, {
+    const res = await fetch(`${BASE_URL}/v2/checkout/orders`, {
       method: "POST",
       headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
       body: JSON.stringify(payload)


### PR DESCRIPTION
## Summary
- always use PayPal sandbox base URL and credentials in Netlify functions and Next.js API routes
- remove PAYPAL_ENV logic to prevent invalid_client errors during auth

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a52da1854c83318a2759b63b023995