### PR TITLE
feat: switch paypal sandbox and live creds

### DIFF
--- a/app/api/paypal/capture/route.js
+++ b/app/api/paypal/capture/route.js
@@ -1,14 +1,21 @@
 import { NextResponse } from "next/server";
 
-const BASE_URL = "https://api-m.sandbox.paypal.com";
+// Determine whether we're in live or sandbox mode
+const mode = process.env.PAYPAL_ENV === "live" ? "live" : "sandbox";
+const BASE_URL =
+  mode === "live"
+    ? "https://api-m.paypal.com"
+    : "https://api-m.sandbox.paypal.com";
 
 async function getAccessToken() {
   const id =
-    process.env.PAYPAL_SANDBOX_CLIENT_ID || process.env.PAYPAL_CLIENT_ID;
+    mode === "live"
+      ? process.env.PAYPAL_CLIENT_ID
+      : process.env.PAYPAL_SANDBOX_CLIENT_ID;
   const secret =
-    process.env.PAYPAL_SANDBOX_CLIENT_SECRET ||
-    process.env.PAYPAL_CLIENT_SECRET ||
-    process.env.PAYPAL_SECRET;
+    mode === "live"
+      ? process.env.PAYPAL_SECRET
+      : process.env.PAYPAL_SANDBOX_CLIENT_SECRET;
   if (!id || !secret) {
     throw new Error("Missing PayPal credentials");
   }

--- a/app/api/paypal/create/route.js
+++ b/app/api/paypal/create/route.js
@@ -1,14 +1,22 @@
 import { NextResponse } from "next/server";
 
-const BASE_URL = "https://api-m.sandbox.paypal.com";
+// Determine mode before making any requests
+const mode = process.env.PAYPAL_ENV === "live" ? "live" : "sandbox";
+const BASE_URL =
+  mode === "live"
+    ? "https://api-m.paypal.com"
+    : "https://api-m.sandbox.paypal.com";
 
 async function getAccessToken() {
+  // Select the correct credentials for the current mode
   const id =
-    process.env.PAYPAL_SANDBOX_CLIENT_ID || process.env.PAYPAL_CLIENT_ID;
+    mode === "live"
+      ? process.env.PAYPAL_CLIENT_ID
+      : process.env.PAYPAL_SANDBOX_CLIENT_ID;
   const secret =
-    process.env.PAYPAL_SANDBOX_CLIENT_SECRET ||
-    process.env.PAYPAL_CLIENT_SECRET ||
-    process.env.PAYPAL_SECRET;
+    mode === "live"
+      ? process.env.PAYPAL_SECRET
+      : process.env.PAYPAL_SANDBOX_CLIENT_SECRET;
   if (!id || !secret) {
     throw new Error("Missing PayPal credentials");
   }


### PR DESCRIPTION
## Summary
- determine PayPal mode via `PAYPAL_ENV` and select appropriate sandbox or live credentials
- use explicit env vars like `PAYPAL_SANDBOX_CLIENT_SECRET` and `PAYPAL_CLIENT_ID` across API routes and shop page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a530febff083319505502fb6d518fa