### PR TITLE
Add PayPal checkout button and environment toggling

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -88,22 +88,5 @@
     inset 0 1px 0 rgba(255,255,255,.35);
 }
 
-/* Dark theme inputs (Shop qty boxes etc) */
-.input-dark{
-  background-image: linear-gradient(180deg, rgba(255,255,255,.12), rgba(255,255,255,.06));
-  border: 1px solid rgba(255,255,255,.22);
-  color:#f1f5f9;
-  box-shadow:
-    inset 0 1px 0 rgba(255,255,255,.08),
-    0 1px 1px rgba(0,0,0,.15);
-}
-.input-dark:focus{
-  outline: none;
-  border-color: rgba(59,130,246,.45);
-  box-shadow:
-    0 0 0 3px rgba(59,130,246,.30),
-    inset 0 1px 0 rgba(255,255,255,.08);
-}
-
 /* Utility */
 .hidden-soft{display:none !important;}

--- a/app/shop/page.jsx
+++ b/app/shop/page.jsx
@@ -94,6 +94,23 @@ export default function ShopPage() {
   }
   function updateQty(key, qty) { setCart(old => old.map(i => i.key === key ? { ...i, qty: Math.max(1, qty) } : i)); }
   function removeItem(key) { setCart(old => old.filter(i => i.key !== key)); }
+  async function checkout() {
+    try {
+      const res = await fetch("/api/paypal/create", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ amount: subtotal.toFixed(2), currency: "USD" })
+      });
+      const data = await res.json();
+      if (data.approve) {
+        window.location.href = data.approve;
+      } else {
+        alert(data.error || "Payment error");
+      }
+    } catch (e) {
+      alert(String(e));
+    }
+  }
 
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pb-24 pt-10">
@@ -124,7 +141,7 @@ export default function ShopPage() {
               <p className="text-xs text-slate-400 mt-1">{p.material} • {p.category}</p>
               <div className="mt-3 flex items-center gap-2">
                 <input type="number" min="1" defaultValue="1" id={`qty-${p.id}`}
-                       className="w-16 rounded-lg input-dark px-2 py-1 text-sm"/>
+                       className="w-16 rounded-lg bubble px-2 py-1 text-sm"/>
                 <button onClick={() => add(p.id, parseInt(document.getElementById(`qty-${p.id}`).value || "1", 10))}
                         className="rounded-lg bubble px-3 py-1.5 text-xs font-semibold hover:brightness-110">
                   Add
@@ -151,7 +168,7 @@ export default function ShopPage() {
                 <div className="mt-2 flex items-center gap-2">
                   <input type="number" min="1" value={it.qty}
                          onChange={(e)=>updateQty(it.key, parseInt(e.target.value||"1",10))}
-                         className="w-16 rounded-lg input-dark px-2 py-1 text-sm"/>
+                         className="w-16 rounded-lg bubble px-2 py-1 text-sm"/>
                   <button onClick={()=>removeItem(it.key)} className="text-xs text-slate-600 hover:text-black">Remove</button>
                 </div>
               </div>
@@ -159,6 +176,10 @@ export default function ShopPage() {
           ))}
         </div>
         <div id="paypal-buttons" className="mt-4" />
+        <button onClick={checkout}
+                className="mt-4 rounded-xl bubble px-4 py-2 text-sm font-semibold hover:brightness-110">
+          Purchase
+        </button>
       </section>
     </div>
   );

--- a/netlify/functions/paypal-capture-order.js
+++ b/netlify/functions/paypal-capture-order.js
@@ -1,12 +1,20 @@
-const BASE_URL = "https://api-m.sandbox.paypal.com";
+// Allow switching between sandbox and live environments via PAYPAL_ENV
+const mode = process.env.PAYPAL_ENV === "live" ? "live" : "sandbox";
+const BASE_URL =
+  mode === "live"
+    ? "https://api-m.paypal.com"
+    : "https://api-m.sandbox.paypal.com";
 
 async function getAccessToken() {
+  // Pick credentials based on mode
   const id =
-    process.env.PAYPAL_SANDBOX_CLIENT_ID || process.env.PAYPAL_CLIENT_ID;
+    mode === "live"
+      ? process.env.PAYPAL_CLIENT_ID
+      : process.env.PAYPAL_SANDBOX_CLIENT_ID;
   const secret =
-    process.env.PAYPAL_SANDBOX_CLIENT_SECRET ||
-    process.env.PAYPAL_CLIENT_SECRET ||
-    process.env.PAYPAL_SECRET;
+    mode === "live"
+      ? process.env.PAYPAL_CLIENT_SECRET || process.env.PAYPAL_SECRET
+      : process.env.PAYPAL_SANDBOX_CLIENT_SECRET;
   if (!id || !secret) {
     throw new Error("Missing PayPal credentials");
   }

--- a/netlify/functions/paypal-create-order.js
+++ b/netlify/functions/paypal-create-order.js
@@ -1,12 +1,20 @@
-const BASE_URL = "https://api-m.sandbox.paypal.com";
+// Allow switching between sandbox and live environments via PAYPAL_ENV
+const mode = process.env.PAYPAL_ENV === "live" ? "live" : "sandbox";
+const BASE_URL =
+  mode === "live"
+    ? "https://api-m.paypal.com"
+    : "https://api-m.sandbox.paypal.com";
 
 async function getAccessToken() {
+  // Pick credentials based on mode
   const id =
-    process.env.PAYPAL_SANDBOX_CLIENT_ID || process.env.PAYPAL_CLIENT_ID;
+    mode === "live"
+      ? process.env.PAYPAL_CLIENT_ID
+      : process.env.PAYPAL_SANDBOX_CLIENT_ID;
   const secret =
-    process.env.PAYPAL_SANDBOX_CLIENT_SECRET ||
-    process.env.PAYPAL_CLIENT_SECRET ||
-    process.env.PAYPAL_SECRET;
+    mode === "live"
+      ? process.env.PAYPAL_CLIENT_SECRET || process.env.PAYPAL_SECRET
+      : process.env.PAYPAL_SANDBOX_CLIENT_SECRET;
   if (!id || !secret) {
     throw new Error("Missing PayPal credentials");
   }


### PR DESCRIPTION
## Summary
- allow PayPal Netlify functions to switch between live and sandbox using PAYPAL_ENV
- style quantity inputs to match theme and add a purchase button that links to PayPal checkout

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a53570d5408331b318e28db1f084de