### PR TITLE
Scope PayPal credentials by environment and update shop UI

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -46,6 +46,14 @@
     inset 0 1px 0 rgba(255,255,255,.25),
     0 1px 6px rgba(0,0,0,.08);
 }
+.bubble-input{
+  background-image: linear-gradient(180deg, rgba(255,255,255,.10), rgba(255,255,255,.04));
+  border: 1px solid rgba(255,255,255,.18);
+  color:#f1f5f9;
+  box-shadow:
+    inset 0 1px 0 rgba(255,255,255,.20),
+    0 1px 4px rgba(0,0,0,.05);
+}
 .bubble-active{
   box-shadow:
     inset 0 0 0 1.5px rgba(255,255,255,.45),

--- a/app/shop/page.jsx
+++ b/app/shop/page.jsx
@@ -141,7 +141,7 @@ export default function ShopPage() {
               <p className="text-xs text-slate-400 mt-1">{p.material} • {p.category}</p>
               <div className="mt-3 flex items-center gap-2">
                 <input type="number" min="1" defaultValue="1" id={`qty-${p.id}`}
-                       className="w-16 rounded-lg bubble px-2 py-1 text-sm"/>
+                       className="w-16 rounded-lg bubble-input px-2 py-1 text-sm"/>
                 <button onClick={() => add(p.id, parseInt(document.getElementById(`qty-${p.id}`).value || "1", 10))}
                         className="rounded-lg bubble px-3 py-1.5 text-xs font-semibold hover:brightness-110">
                   Add
@@ -168,7 +168,7 @@ export default function ShopPage() {
                 <div className="mt-2 flex items-center gap-2">
                   <input type="number" min="1" value={it.qty}
                          onChange={(e)=>updateQty(it.key, parseInt(e.target.value||"1",10))}
-                         className="w-16 rounded-lg bubble px-2 py-1 text-sm"/>
+                         className="w-16 rounded-lg bubble-input px-2 py-1 text-sm"/>
                   <button onClick={()=>removeItem(it.key)} className="text-xs text-slate-600 hover:text-black">Remove</button>
                 </div>
               </div>
@@ -177,8 +177,8 @@ export default function ShopPage() {
         </div>
         <div id="paypal-buttons" className="mt-4" />
         <button onClick={checkout}
-                className="mt-4 rounded-xl bubble px-4 py-2 text-sm font-semibold hover:brightness-110">
-          Purchase
+                className="mt-4 w-40 mx-auto block rounded-xl bubble px-4 py-2 text-sm font-semibold text-center hover:brightness-110">
+          Checkout
         </button>
       </section>
     </div>

--- a/netlify/functions/paypal-capture-order.js
+++ b/netlify/functions/paypal-capture-order.js
@@ -13,7 +13,7 @@ async function getAccessToken() {
       : process.env.PAYPAL_SANDBOX_CLIENT_ID;
   const secret =
     mode === "live"
-      ? process.env.PAYPAL_CLIENT_SECRET || process.env.PAYPAL_SECRET
+      ? process.env.PAYPAL_SECRET
       : process.env.PAYPAL_SANDBOX_CLIENT_SECRET;
   if (!id || !secret) {
     throw new Error("Missing PayPal credentials");

--- a/netlify/functions/paypal-create-order.js
+++ b/netlify/functions/paypal-create-order.js
@@ -13,7 +13,7 @@ async function getAccessToken() {
       : process.env.PAYPAL_SANDBOX_CLIENT_ID;
   const secret =
     mode === "live"
-      ? process.env.PAYPAL_CLIENT_SECRET || process.env.PAYPAL_SECRET
+      ? process.env.PAYPAL_SECRET
       : process.env.PAYPAL_SANDBOX_CLIENT_SECRET;
   if (!id || !secret) {
     throw new Error("Missing PayPal credentials");


### PR DESCRIPTION
## Summary
- Scope PayPal API routes and Netlify functions to use PAYPAL_CLIENT_ID/PAYPAL_SECRET for live and PAYPAL_SANDBOX_CLIENT_ID/PAYPAL_SANDBOX_CLIENT_SECRET for sandbox
- Style quantity inputs with a bubble look and rename Purchase button to centered Checkout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a53909af4c8331ae0dba8165f146d0