### PR TITLE
Fix PayPal capture request content type

### DIFF
--- a/netlify/functions/paypal-capture-order.js
+++ b/netlify/functions/paypal-capture-order.js
@@ -33,7 +33,11 @@ exports.handler = async (event) => {
     const token = await getAccessToken();
     const res = await fetch(`${base}/v2/checkout/orders/${orderId}/capture`, {
       method: "POST",
-      headers: { Authorization: `Bearer ${token}` }
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json"
+      },
+      body: "{}"
     });
     const capture = await res.json();
     return {


### PR DESCRIPTION
## Summary
- send `Content-Type: application/json` with an empty body when capturing PayPal orders to match API requirements

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5fe5029f8833183a565c588fa1f8f