### PR TITLE
Add inventory-driven options and PayPal line items

### DIFF
--- a/app/design/page.jsx
+++ b/app/design/page.jsx
@@ -1,5 +1,8 @@
 "use client";
 
+import INV from "../../lib/inventory.json";
+const { MATERIALS, COLORS } = INV;
+
 export default function DesignPage() {
   return (
     <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 pb-24 pt-10 space-y-10">
@@ -69,12 +72,17 @@ export default function DesignPage() {
             </label>
           </div>
 
-          <div className="grid sm:grid-cols-3 gap-4">
+          <div className="grid sm:grid-cols-4 gap-4">
             <label className="block">
               <div className="text-sm text-slate-300 mb-1">Material</div>
               <select name="material" className="w-full rounded-xl input-soft px-3 py-2 text-sm">
-                <option>PLA</option><option>PETG</option><option>ABS</option><option>ASA</option>
-                <option>Nylon</option><option>CF-Nylon</option><option>TPU 95A</option>
+                {MATERIALS.map(m => <option key={m}>{m}</option>)}
+              </select>
+            </label>
+            <label className="block">
+              <div className="text-sm text-slate-300 mb-1">Color</div>
+              <select name="color" className="w-full rounded-xl input-soft px-3 py-2 text-sm">
+                {COLORS.map(c => <option key={c}>{c}</option>)}
               </select>
             </label>
             <label className="block">

--- a/lib/inventory.json
+++ b/lib/inventory.json
@@ -1,0 +1,4 @@
+{
+  "MATERIALS": ["PLA","PETG","ABS","ASA","Nylon","CF-Nylon","TPU 95A"],
+  "COLORS": ["Black","White","Gray","Blue","Red","Green","Natural","Orange","Yellow"]
+}

--- a/netlify/functions/paypal-utils.js
+++ b/netlify/functions/paypal-utils.js
@@ -1,0 +1,24 @@
+const base = "https://api-m.sandbox.paypal.com";
+const id = process.env.NEXT_PUBLIC_PAYPAL_ID;
+const secret = process.env.PAYPAL_SECRET;
+
+async function getAccessToken() {
+  if (!id || !secret) throw new Error("Missing PayPal env vars (NEXT_PUBLIC_PAYPAL_ID / PAYPAL_SECRET)");
+  const creds = Buffer.from(`${id}:${secret}`).toString("base64");
+  const res = await fetch(`${base}/v1/oauth2/token`, {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${creds}`,
+      "Content-Type": "application/x-www-form-urlencoded"
+    },
+    body: "grant_type=client_credentials"
+  });
+  const text = await res.text();
+  if (!res.ok) throw new Error(`PayPal auth failed (${res.status}): ${text || res.statusText}`);
+  return JSON.parse(text).access_token;
+}
+
+const round2 = (n) => Math.round(n * 100) / 100;
+const json = (statusCode, body) => ({ statusCode, headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
+
+module.exports = { base, id, secret, getAccessToken, round2, json };


### PR DESCRIPTION
## Summary
- Add shared material/color inventory and use it on design and shop pages
- Capture selected material/color for cart items and PayPal order creation
- Include line items and sales tax logic in PayPal functions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a60f0eb9f88331a51cb75b73853109