### PR TITLE
feat: email design requests

### DIFF
--- a/app/design/page.jsx
+++ b/app/design/page.jsx
@@ -46,7 +46,7 @@ export default function DesignPage() {
         <h3 className="text-xl font-semibold">Design & Quote</h3>
         <p className="text-slate-200 mt-2">Tell us what you need. Attach CAD/mesh files if you have them.</p>
 
-        <form id="quote-form" className="mt-6 space-y-6" onSubmit={(e) => {
+        <form id="quote-form" className="mt-6 space-y-6" onSubmit={async (e) => {
           e.preventDefault();
           const data = Object.fromEntries(new FormData(e.currentTarget).entries());
           const files = (e.currentTarget.querySelector("#file-input")?.files || []);
@@ -56,6 +56,15 @@ export default function DesignPage() {
             files: Array.from(files).map(f => f.name),
             time: new Date().toISOString()
           };
+          try {
+            await fetch("/api/design-request", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify(payload)
+            });
+          } catch (err) {
+            console.error("Failed to send design request", err);
+          }
           const prev = JSON.parse(localStorage.getItem("dixon3d_requests") || "[]");
           localStorage.setItem("dixon3d_requests", JSON.stringify([payload, ...prev]));
           e.currentTarget.reset();

--- a/netlify.toml
+++ b/netlify.toml
@@ -16,5 +16,10 @@
   to   = "/.netlify/functions/paypal-capture-order"
   status = 200
 
+[[redirects]]
+  from = "/api/design-request"
+  to   = "/.netlify/functions/design-request"
+  status = 200
+
 [[plugins]]
   package = "@netlify/plugin-nextjs"

--- a/netlify/functions/design-request.js
+++ b/netlify/functions/design-request.js
@@ -1,0 +1,50 @@
+const nodemailer = require("nodemailer");
+
+exports.handler = async (event) => {
+  if (event.httpMethod !== "POST") {
+    return { statusCode: 405, body: "Method Not Allowed" };
+  }
+
+  try {
+    const data = JSON.parse(event.body || "{}");
+    const {
+      name = "",
+      email = "",
+      material = "",
+      color = "",
+      quantity = "",
+      finish = "",
+      notes = "",
+      files = [],
+      time = "",
+    } = data;
+
+    const transporter = nodemailer.createTransport({
+      host: process.env.SMTP_HOST,
+      port: Number(process.env.SMTP_PORT) || 587,
+      secure: process.env.SMTP_SECURE === "true",
+      auth: {
+        user: process.env.SMTP_USER,
+        pass: process.env.SMTP_PASS,
+      },
+    });
+
+    const text = `New design request\n\nName: ${name}\nEmail: ${email}\nMaterial: ${material}\nColor: ${color}\nQuantity: ${quantity}\nFinish: ${finish}\nNotes: ${notes}\nFiles: ${files.join(", ")}\nTime: ${time}`;
+
+    await transporter.sendMail({
+      from: process.env.SMTP_FROM || process.env.SMTP_USER,
+      to: "ThomasDixon@dixon3d.com",
+      subject: "New Design Request",
+      text,
+    });
+
+    return { statusCode: 200, body: JSON.stringify({ ok: true }) };
+  } catch (err) {
+    console.error(err);
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: "Failed to send email" }),
+    };
+  }
+};
+

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "dependencies": {
     "next": "14.2.5",
     "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react-dom": "18.3.1",
+    "nodemailer": "^6.9.8"
   },
   "devDependencies": {
     "@netlify/plugin-nextjs": "5.12.0",


### PR DESCRIPTION
## Summary
- send design request form submissions to ThomasDixon@dixon3d.com via new Netlify function
- forward `/api/design-request` to the function through Netlify redirect
- post design request details from the client form
- add nodemailer dependency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(stalls during build; partial log collected)*

------
https://chatgpt.com/codex/tasks/task_e_68a61e97a22883318ff661c50758dfc1