### PR TITLE
Ensure design requests send email before redirect

### DIFF
--- a/app/design/page.jsx
+++ b/app/design/page.jsx
@@ -57,18 +57,20 @@ export default function DesignPage() {
             time: new Date().toISOString()
           };
           try {
-            await fetch("/api/design-request", {
+            const res = await fetch("/api/design-request", {
               method: "POST",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify(payload)
             });
+            if (!res.ok) throw new Error("Failed to send design request");
+            const prev = JSON.parse(localStorage.getItem("dixon3d_requests") || "[]");
+            localStorage.setItem("dixon3d_requests", JSON.stringify([payload, ...prev]));
+            e.currentTarget.reset();
+            window.location.href = "/design/thank-you";
           } catch (err) {
             console.error("Failed to send design request", err);
+            alert("Failed to send design request. Please try again later.");
           }
-          const prev = JSON.parse(localStorage.getItem("dixon3d_requests") || "[]");
-          localStorage.setItem("dixon3d_requests", JSON.stringify([payload, ...prev]));
-          e.currentTarget.reset();
-          window.location.href = "/design/thank-you";
         }}>
           <div className="grid sm:grid-cols-2 gap-4">
             <label className="block">

--- a/netlify/functions/design-request.js
+++ b/netlify/functions/design-request.js
@@ -34,6 +34,7 @@ exports.handler = async (event) => {
     await transporter.sendMail({
       from: process.env.SMTP_FROM || process.env.SMTP_USER,
       to: "ThomasDixon@dixon3d.com",
+      replyTo: email || undefined,
       subject: "New Design Request",
       text,
     });


### PR DESCRIPTION
## Summary
- verify design request form waits for successful email before redirecting to thank-you page
- add reply-to header when emailing new design requests

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a623655680833195f1e375da1d8ffc