### PR TITLE
feat: display design examples orbit carousel

### DIFF
--- a/app/design/page.jsx
+++ b/app/design/page.jsx
@@ -6,9 +6,14 @@ import { EXAMPLES } from "../../lib/examples";
 const { MATERIALS, COLORS } = INV;
 
 export default function DesignPage() {
-  const designImgs = EXAMPLES.filter(e => e.process === "design").map(e => ({
+  let imgs = EXAMPLES.filter(e => e.process === "design");
+  if (imgs.length === 0) {
+    const common = EXAMPLES.filter(e => ["fdm", "cad"].includes(e.process));
+    imgs = common.length > 0 ? common : EXAMPLES;
+  }
+  const orbitImgs = imgs.map(e => ({
     src: e.src,
-    alt: e.alt,
+    alt: e.title ?? e.alt ?? "Example",
     caption: e.title,
   }));
 
@@ -78,7 +83,11 @@ export default function DesignPage() {
         </div>
       </section>
 
-      <ExamplesOrbit images={designImgs} className="my-12" />
+      {orbitImgs.length > 0 ? (
+        <ExamplesOrbit images={orbitImgs} className="my-12" />
+      ) : (
+        <p className="my-12 text-center text-sm text-slate-400">No examples available.</p>
+      )}
 
       <section>
         <h3 className="text-xl font-semibold">Design & Quote</h3>


### PR DESCRIPTION
## Summary
- show ExamplesOrbit carousel after reviews on Design page
- fallback to other processes or all examples if no design examples
- add empty state when examples array empty

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7e0f3771c8331ab879dac5dd91804