### PR TITLE
Use block ref assignment in carousel component

### DIFF
--- a/components/ExamplesOrbit.tsx
+++ b/components/ExamplesOrbit.tsx
@@ -167,7 +167,9 @@ export default function ExamplesOrbit({
       {images.map((img, i) => (
         <div
           key={i}
-          ref={el => (itemsRef.current[i] = el!)}
+          ref={el => {
+            itemsRef.current[i] = el!;
+          }}
           className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-xl"
         >
           <Image


### PR DESCRIPTION
## Summary
- avoid returning the assigned element in `ExamplesOrbit` by using a block ref callback

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8cafa1a3c8331ac43831afdbf399d