### PR TITLE
Revamp shop pricing and design spotlight

### DIFF
--- a/app/design/page.jsx
+++ b/app/design/page.jsx
@@ -42,7 +42,22 @@ export default function DesignPage() {
     }
   }
   return (
-    <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 pb-24 pt-10 space-y-10">
+    <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 pb-24 pt-10 space-y-10">
+      <section className="rounded-3xl panel p-4">
+        <h3 className="text-xl font-semibold mb-3">Spotlight</h3>
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-3">
+          {imgs.length > 0 ? (
+            imgs.map(img => (
+              <figure key={img.src} className="relative overflow-hidden rounded-2xl bubble aspect-square">
+                <Image src={img.src} alt={img.title ?? img.alt ?? 'Example'} fill className="object-cover" />
+              </figure>
+            ))
+          ) : (
+            <p className="col-span-full text-center text-sm text-slate-400">No examples available.</p>
+          )}
+        </div>
+      </section>
+
       <h2 className="text-2xl font-bold">Design Work</h2>
 
       <section className="grid md:grid-cols-2 gap-4">
@@ -76,21 +91,6 @@ export default function DesignPage() {
             <p className="text-sm mt-1">“Clear communication on limitations and material choice.”</p>
             <div className="text-xs text-slate-300 mt-2">— Chelsey S.</div>
           </article>
-        </div>
-      </section>
-
-      <section className="rounded-3xl panel p-4">
-        <h3 className="text-xl font-semibold mb-3">Work Under Review</h3>
-        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-3">
-          {imgs.length > 0 ? (
-            imgs.map(img => (
-              <figure key={img.src} className="relative overflow-hidden rounded-2xl bubble aspect-square">
-                <Image src={img.src} alt={img.title ?? img.alt ?? 'Example'} fill className="object-cover" />
-              </figure>
-            ))
-          ) : (
-            <p className="col-span-full text-center text-sm text-slate-400">No examples available.</p>
-          )}
         </div>
       </section>
 

--- a/app/shop/page.jsx
+++ b/app/shop/page.jsx
@@ -11,18 +11,19 @@ const money = (n) => "$" + (Math.round(n * 100) / 100).toFixed(2);
 const PRODUCTS = [
   {
     id: "card",
-    name: "Custom Business Cards",
-    price: 12.0,
+    name: "Custom Business Cards (10x)",
+    price: 5.0,
     material: "PLA",
     color: "Black",
     description: "Durable printed cards tailored to your brand.",
     images: ["/assets/img/BusinessCard_Printed.png"],
     customize: true,
+    noMC: true,
   },
   {
     id: "chessboard",
     name: "Magnetic Puzzle Chessboard w/ Pieces",
-    price: 8.5,
+    price: 40.0,
     material: "PLA",
     description: "Modular magnetic chessboard with puzzle-fit pieces.",
     images: [
@@ -33,21 +34,22 @@ const PRODUCTS = [
   {
     id: "insole",
     name: "Custom TPU Insole",
-    price: 30.0,
+    price: 20.0,
     material: "TPU 95A",
     description: "Tailored insoles for comfort.",
   },
   {
     id: "planter",
-    name: "Geometric Planter (120mm)",
-    price: 18.0,
+    name: "Plant Pot - 1.5 gal",
+    price: 12.5,
     material: "PLA",
     description: "Faceted planter for small succulents.",
+    images: ["/assets/img/HalfGal_PlantHolder.png"],
   },
   {
     id: "pegboard",
     name: "Customizable Pegboard",
-    price: 14.0,
+    price: 50.0,
     material: "ABS",
     color: "Black",
     description:
@@ -63,7 +65,7 @@ const PRODUCTS = [
   {
     id: "enclosure",
     name: "Custom Sized Framing/Enclosure",
-    price: 0.0,
+    price: null,
     material: "PLA",
     color: "Black",
     description: "Submit your dimensions for a tailored frame or enclosure.",
@@ -72,6 +74,7 @@ const PRODUCTS = [
       "/assets/img/Enclosure_Drawing.png",
     ],
     customize: true,
+    noMC: true,
   },
 ];
 
@@ -199,7 +202,9 @@ export default function ShopPage() {
         <div className="p-4">
           <div className="flex items-center justify-between gap-2">
             <h3 className="font-semibold text-white">{p.name}</h3>
-            <span className="text-sm text-slate-300">{money(p.price)}</span>
+            <span className="text-sm text-slate-300">
+              {p.price == null ? "Variable" : money(p.price)}
+            </span>
           </div>
           {p.description && (
             <p className="text-xs text-slate-400 mt-1">{p.description}</p>
@@ -207,22 +212,24 @@ export default function ShopPage() {
           <div className="mt-3 space-y-2">
             {p.customize ? (
               <>
-                <div className="flex gap-2">
-                  <select
-                    disabled
-                    defaultValue={p.material}
-                    className="rounded-lg bubble-input px-2 py-1 text-xs opacity-50"
-                  >
-                    <option>{p.material}</option>
-                  </select>
-                  <select
-                    disabled
-                    defaultValue={p.color}
-                    className="rounded-lg bubble-input px-2 py-1 text-xs opacity-50"
-                  >
-                    <option>{p.color}</option>
-                  </select>
-                </div>
+                {!p.noMC && (
+                  <div className="flex gap-2">
+                    <select
+                      disabled
+                      defaultValue={p.material}
+                      className="rounded-lg bubble-input px-2 py-1 text-xs opacity-50"
+                    >
+                      <option>{p.material}</option>
+                    </select>
+                    <select
+                      disabled
+                      defaultValue={p.color}
+                      className="rounded-lg bubble-input px-2 py-1 text-xs opacity-50"
+                    >
+                      <option>{p.color}</option>
+                    </select>
+                  </div>
+                )}
                 <Link
                   href="/design#quote-form"
                   className="block text-center rounded-lg bubble px-3 py-1.5 text-xs font-semibold hover:brightness-110"


### PR DESCRIPTION
## Summary
- rename Geometric Planter to Plant Pot and reference existing `HalfGal_PlantHolder` image
- adjust product prices and business card bundle name
- add Spotlight gallery to design page with wider banner

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a921d6998c83319c2574d23992ef05