### PR TITLE
Tweak To Replace example image sizes to align with other categories

### DIFF
--- a/app/design/page.jsx
+++ b/app/design/page.jsx
@@ -83,7 +83,15 @@ export default function DesignPage() {
             <div className="grid gap-3">
               {group.images.map(img => (
                 <div key={img.src} className="text-center space-y-1">
-                    <figure className={`relative overflow-hidden rounded-2xl bubble ${group.landscape ? 'aspect-[16/9]' : 'aspect-square'}`}>
+                    <figure
+                      className={`relative overflow-hidden rounded-2xl bubble ${
+                        group.landscape
+                          ? group.images.length > 1
+                            ? 'aspect-[2/1]'
+                            : 'aspect-[16/9]'
+                          : 'aspect-square'
+                      }`}
+                    >
                       <Image src={img.src} alt={img.alt} fill className="object-cover" />
                     </figure>
                     <div className="text-xs text-slate-300">{img.caption}</div>


### PR DESCRIPTION
## Summary
- Resize "To Replace" images to a 2:1 aspect ratio when multiple landscape images exist so examples line up with mockup and final

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa532bccc8833182e1f47d4f04db77