### PR TITLE
feat: add Info tab to navigation

### DIFF
--- a/app/info/[slug]/page.tsx
+++ b/app/info/[slug]/page.tsx
@@ -1,0 +1,47 @@
+import path from "path";
+import fs from "fs/promises";
+import Image from "next/image";
+import { notFound } from "next/navigation";
+import type { InfoPost } from "../../../lib/info";
+
+interface Params { params: { slug: string } }
+
+export default async function InfoPostPage({ params }: Params) {
+  const { slug } = params;
+  const file = path.join(process.cwd(), "content/info", `${slug}.json`);
+  let data: InfoPost;
+  try {
+    const raw = await fs.readFile(file, "utf-8");
+    data = { ...JSON.parse(raw), slug };
+  } catch (e) {
+    notFound();
+  }
+  const post = data!;
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-8 space-y-4">
+      <h1 className="text-3xl font-bold">{post.title}</h1>
+      <p className="text-sm text-slate-300">
+        {new Date(post.date).toLocaleDateString()} • {post.minutes} min read
+      </p>
+      {post.hero && (
+        <div className="relative w-full h-64">
+          <Image src={post.hero} alt={post.title} fill className="object-cover rounded" />
+        </div>
+      )}
+      <p>{post.summary}</p>
+      {post.video && (
+        <video src={post.video} controls className="w-full rounded" />
+      )}
+      {post.externalUrl && (
+        <a
+          href={post.externalUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-block bubble px-4 py-2 rounded mt-4"
+        >
+          Read at source
+        </a>
+      )}
+    </div>
+  );
+}

--- a/app/info/page.tsx
+++ b/app/info/page.tsx
@@ -1,0 +1,13 @@
+import InfoFilters from "../../components/InfoFilters";
+import { getExternalNews, getLocalPosts } from "../../lib/info";
+
+export default async function InfoPage() {
+  const localPosts = await getLocalPosts();
+  const newsItems = await getExternalNews();
+  return (
+    <div className="max-w-7xl mx-auto px-4 py-8">
+      <h1 className="text-3xl font-bold mb-8">Info</h1>
+      <InfoFilters localPosts={localPosts} newsItems={newsItems} />
+    </div>
+  );
+}

--- a/components/InfoCard.tsx
+++ b/components/InfoCard.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import type { InfoPost, NewsItem } from "../lib/info";
+
+export interface InfoCardProps {
+  title: string;
+  summary?: string;
+  date: string;
+  source: string;
+  href: string;
+  hero?: string;
+  external?: boolean;
+}
+
+export default function InfoCard(props: InfoCardProps) {
+  const { title, summary, date, source, href, hero, external } = props;
+  const content = (
+    <div className="card rounded-lg overflow-hidden flex flex-col h-full transition hover:bg-white/10">
+      {hero && (
+        <div className="relative h-40 w-full">
+          <Image src={hero} alt={title} fill className="object-cover" />
+        </div>
+      )}
+      <div className="p-4 flex flex-col flex-1">
+        <h3 className="text-lg font-semibold mb-2">{title}</h3>
+        {summary && <p className="text-sm mb-4 flex-1">{summary}</p>}
+        <div className="mt-auto text-xs text-slate-300">
+          {new Date(date).toLocaleDateString()} • {source}
+        </div>
+      </div>
+    </div>
+  );
+  return external ? (
+    <a href={href} target="_blank" rel="noopener noreferrer">
+      {content}
+    </a>
+  ) : (
+    <Link href={href}>{content}</Link>
+  );
+}
+
+export function fromLocal(post: InfoPost): InfoCardProps {
+  return {
+    title: post.title,
+    summary: post.summary,
+    date: post.date,
+    source: post.externalUrl ? "External" : "Dixon3D",
+    href: post.externalUrl ? post.externalUrl : `/info/${post.slug}`,
+    hero: post.hero || undefined,
+    external: !!post.externalUrl,
+  };
+}
+
+export function fromNews(item: NewsItem): InfoCardProps {
+  return {
+    title: item.title,
+    summary: item.summary,
+    date: item.date,
+    source: item.source,
+    href: item.url,
+    external: true,
+  };
+}

--- a/components/InfoFilters.tsx
+++ b/components/InfoFilters.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import InfoCard, { fromLocal, fromNews } from "./InfoCard";
+import type { InfoCategory, InfoPost, NewsItem } from "../lib/info";
+
+const CATEGORIES: { key: InfoCategory; label: string }[] = [
+  { key: "guides", label: "Guides" },
+  { key: "processes-materials", label: "Processes & Materials" },
+  { key: "design-slicing", label: "Design & Slicing" },
+  { key: "post-quality", label: "Post Quality" },
+  { key: "production-ops", label: "Production & Ops" },
+  { key: "case-studies", label: "Case Studies" },
+];
+
+interface Props {
+  localPosts: InfoPost[];
+  newsItems: NewsItem[];
+}
+
+export default function InfoFilters({ localPosts, newsItems }: Props) {
+  const [category, setCategory] = useState<string>("all");
+  const [query, setQuery] = useState("");
+
+  const filtered = useMemo(() => {
+    const q = query.toLowerCase();
+    return localPosts.filter((p) => {
+      const inCategory = category === "all" || p.category === category;
+      const text = `${p.title} ${p.summary} ${p.tags.join(" ")}`.toLowerCase();
+      const matches = text.includes(q);
+      return inCategory && matches;
+    });
+  }, [localPosts, category, query]);
+
+  return (
+    <div className="space-y-10">
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+        <div className="flex flex-wrap gap-2">
+          <button
+            onClick={() => setCategory("all")}
+            className={`px-3 py-1.5 rounded-full text-sm bubble ${
+              category === "all" ? "bubble-active" : ""
+            }`}
+          >
+            All
+          </button>
+          {CATEGORIES.map((c) => (
+            <button
+              key={c.key}
+              onClick={() => setCategory(c.key)}
+              className={`px-3 py-1.5 rounded-full text-sm bubble ${
+                category === c.key ? "bubble-active" : ""
+              }`}
+            >
+              {c.label}
+            </button>
+          ))}
+        </div>
+        <input
+          type="text"
+          placeholder="Search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          className="bubble-input rounded-full px-3 py-1.5 text-sm"
+        />
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {filtered.map((post) => (
+          <InfoCard key={post.slug} {...fromLocal(post)} />
+        ))}
+      </div>
+
+      {newsItems.length > 0 && (
+        <div>
+          <h2 className="text-xl font-semibold mb-4">Latest from the community</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            {newsItems.map((item) => (
+              <InfoCard key={item.url} {...fromNews(item)} />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/Nav.jsx
+++ b/components/Nav.jsx
@@ -37,6 +37,7 @@ export default function Nav() {
 
         <nav className="hidden md:flex flex-1 items-center justify-center gap-2">
           {tab("/", "Home")}
+          {tab("/info", "Info")}
           {tab("/design", "Design Work")}
           {tab("/shop", "Shop Prints")}
         </nav>
@@ -67,6 +68,7 @@ export default function Nav() {
             {open && (
               <div className="absolute right-0 mt-2 w-48 rounded-md bg-header/95 backdrop-blur shadow-lg ring-1 ring-black/5 p-2 flex flex-col gap-1">
                 {tab("/", "Home")}
+                {tab("/info", "Info")}
                 {tab("/design", "Design Work")}
                 {tab("/shop", "Shop Prints")}
               </div>

--- a/content/info/heatset-inserts.json
+++ b/content/info/heatset-inserts.json
@@ -1,0 +1,11 @@
+{
+  "title": "Heat-set inserts: hole sizes & dwell",
+  "category": "design-slicing",
+  "tags": ["fdm", "inserts", "dfam", "petg"],
+  "date": "2025-08-23",
+  "summary": "Quick chart for M3–M5 heat-sets...",
+  "hero": "/images/info/heatsets/hero.jpg",
+  "externalUrl": null,
+  "video": null,
+  "minutes": 3
+}

--- a/content/info/orient-for-strength.json
+++ b/content/info/orient-for-strength.json
@@ -1,0 +1,11 @@
+{
+  "title": "Orient for strength: FDM basics",
+  "category": "design-slicing",
+  "tags": ["fdm", "strength"],
+  "date": "2025-04-10",
+  "summary": "Choosing print orientation for maximum strength.",
+  "hero": "/images/info/orient-strength/hero.jpg",
+  "externalUrl": null,
+  "video": null,
+  "minutes": 4
+}

--- a/lib/info.ts
+++ b/lib/info.ts
@@ -1,0 +1,58 @@
+import fs from "fs/promises";
+import path from "path";
+
+export type InfoCategory =
+  | "guides"
+  | "processes-materials"
+  | "design-slicing"
+  | "post-quality"
+  | "production-ops"
+  | "case-studies";
+
+export interface InfoPost {
+  slug: string;
+  title: string;
+  category: InfoCategory;
+  tags: string[];
+  date: string;
+  summary: string;
+  hero?: string;
+  externalUrl: string | null;
+  video: string | null;
+  minutes: number;
+}
+
+export const INFO_CATEGORIES: { key: InfoCategory; label: string }[] = [
+  { key: "guides", label: "Guides" },
+  { key: "processes-materials", label: "Processes & Materials" },
+  { key: "design-slicing", label: "Design & Slicing" },
+  { key: "post-quality", label: "Post Quality" },
+  { key: "production-ops", label: "Production & Ops" },
+  { key: "case-studies", label: "Case Studies" },
+];
+
+export async function getLocalPosts(): Promise<InfoPost[]> {
+  const dir = path.join(process.cwd(), "content/info");
+  const files = await fs.readdir(dir);
+  const posts: InfoPost[] = [];
+  for (const file of files) {
+    if (!file.endsWith(".json")) continue;
+    const filePath = path.join(dir, file);
+    const raw = await fs.readFile(filePath, "utf-8");
+    const data = JSON.parse(raw);
+    posts.push({ ...data, slug: file.replace(/\.json$/, "") });
+  }
+  return posts.sort((a, b) => (a.date < b.date ? 1 : -1));
+}
+
+export type NewsItem = {
+  title: string;
+  url: string;
+  source: string;
+  date: string;
+  summary?: string;
+};
+
+export async function getExternalNews(): Promise<NewsItem[]> {
+  return [];
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "@netlify/plugin-nextjs": "5.12.0",
     "autoprefixer": "10.4.18",
     "postcss": "8.4.35",
-    "tailwindcss": "3.4.3"
+    "tailwindcss": "3.4.3",
+    "typescript": "5.4.5",
+    "@types/react": "18.3.3",
+    "@types/node": "20.12.12"
   }
 }


### PR DESCRIPTION
## Summary
- expose Info section via new nav link

## Testing
- ❌ `npm install --no-audit --no-fund` (403 Forbidden: unable to fetch packages)
- ⚠️ `npm run build` (missing TypeScript dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68aa56493d208331ba777004851dee6a