### PR TITLE
Revamp info page layout and article display

### DIFF
--- a/app/info/[slug]/page.tsx
+++ b/app/info/[slug]/page.tsx
@@ -18,16 +18,25 @@ export default async function InfoPostPage({ params }: Params) {
   }
   const post = data!;
   return (
-    <div className="max-w-3xl mx-auto px-4 py-8 space-y-4">
-      <h1 className="text-3xl font-bold">{post.title}</h1>
-      <p className="text-sm text-slate-300">
-        {new Date(post.date).toLocaleDateString()} • {post.minutes} min read
-      </p>
-      {post.hero && (
-        <div className="relative w-full h-64">
-          <Image src={post.hero} alt={post.title} fill className="object-cover rounded" />
+    <div className="max-w-3xl mx-auto px-4 py-8 space-y-6">
+      <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-6">
+        <div className="flex-1">
+          <h1 className="text-3xl font-bold">{post.title}</h1>
+          <p className="text-sm text-slate-300 mt-1">
+            {new Date(post.date).toLocaleDateString()} • Dixon3D
+          </p>
         </div>
-      )}
+        {post.hero && (
+          <div className="relative w-full md:w-2/3 h-56 md:h-72 flex-shrink-0">
+            <Image
+              src={post.hero}
+              alt={post.title}
+              fill
+              className="object-cover rounded"
+            />
+          </div>
+        )}
+      </div>
       <p>{post.summary}</p>
       {post.video && (
         <video src={post.video} controls className="w-full rounded" />

--- a/app/info/page.tsx
+++ b/app/info/page.tsx
@@ -6,7 +6,8 @@ export default async function InfoPage() {
   const newsItems = await getExternalNews();
   return (
     <div className="max-w-7xl mx-auto px-4 py-8">
-      <h1 className="text-3xl font-bold mb-8">Info</h1>
+      <h1 className="text-3xl font-bold mb-2">Info</h1>
+      <p className="text-lg text-slate-300 mb-8">Learning and News</p>
       <InfoFilters localPosts={localPosts} newsItems={newsItems} />
     </div>
   );

--- a/components/InfoCard.tsx
+++ b/components/InfoCard.tsx
@@ -6,30 +6,34 @@ import type { InfoPost, NewsItem } from "../lib/info";
 
 export interface InfoCardProps {
   title: string;
-  summary?: string;
   date: string;
-  source: string;
+  author: string;
   href: string;
-  hero?: string;
+  thumbnail?: string;
   external?: boolean;
 }
 
-export default function InfoCard(props: InfoCardProps) {
-  const { title, summary, date, source, href, hero, external } = props;
+export default function InfoCard({
+  title,
+  date,
+  author,
+  href,
+  thumbnail,
+  external,
+}: InfoCardProps) {
   const content = (
-    <div className="card rounded-lg overflow-hidden flex flex-col h-full transition hover:bg-white/10">
-      {hero && (
-        <div className="relative h-40 w-full">
-          <Image src={hero} alt={title} fill className="object-cover" />
+    <div className="card rounded-lg overflow-hidden flex items-center justify-between p-4 transition hover:bg-white/10">
+      <div className="flex-1">
+        <h3 className="text-lg font-semibold">{title}</h3>
+        <p className="text-xs text-slate-300 mt-1">
+          {new Date(date).toLocaleDateString()} • {author}
+        </p>
+      </div>
+      {thumbnail && (
+        <div className="relative w-24 h-16 ml-4 flex-shrink-0">
+          <Image src={thumbnail} alt={title} fill className="object-cover rounded" />
         </div>
       )}
-      <div className="p-4 flex flex-col flex-1">
-        <h3 className="text-lg font-semibold mb-2">{title}</h3>
-        {summary && <p className="text-sm mb-4 flex-1">{summary}</p>}
-        <div className="mt-auto text-xs text-slate-300">
-          {new Date(date).toLocaleDateString()} • {source}
-        </div>
-      </div>
     </div>
   );
   return external ? (
@@ -44,11 +48,10 @@ export default function InfoCard(props: InfoCardProps) {
 export function fromLocal(post: InfoPost): InfoCardProps {
   return {
     title: post.title,
-    summary: post.summary,
     date: post.date,
-    source: post.externalUrl ? "External" : "Dixon3D",
+    author: "Dixon3D",
     href: post.externalUrl ? post.externalUrl : `/info/${post.slug}`,
-    hero: post.hero || undefined,
+    thumbnail: post.hero || undefined,
     external: !!post.externalUrl,
   };
 }
@@ -56,10 +59,11 @@ export function fromLocal(post: InfoPost): InfoCardProps {
 export function fromNews(item: NewsItem): InfoCardProps {
   return {
     title: item.title,
-    summary: item.summary,
     date: item.date,
-    source: item.source,
+    author: item.author ? `${item.author}, ${item.source}` : item.source,
     href: item.url,
+    thumbnail: item.image || undefined,
     external: true,
   };
 }
+

--- a/components/InfoFilters.tsx
+++ b/components/InfoFilters.tsx
@@ -33,8 +33,8 @@ export default function InfoFilters({ localPosts, newsItems }: Props) {
   }, [localPosts, category, query]);
 
   return (
-    <div className="space-y-10">
-      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+    <div className="space-y-14">
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-6">
         <div className="flex flex-wrap gap-2">
           <button
             onClick={() => setCategory("all")}
@@ -65,7 +65,7 @@ export default function InfoFilters({ localPosts, newsItems }: Props) {
         />
       </div>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+      <div className="space-y-4">
         {filtered.map((post) => (
           <InfoCard key={post.slug} {...fromLocal(post)} />
         ))}
@@ -74,7 +74,7 @@ export default function InfoFilters({ localPosts, newsItems }: Props) {
       {newsItems.length > 0 && (
         <div>
           <h2 className="text-xl font-semibold mb-4">Latest from the community</h2>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          <div className="space-y-4">
             {newsItems.map((item) => (
               <InfoCard key={item.url} {...fromNews(item)} />
             ))}

--- a/lib/info.ts
+++ b/lib/info.ts
@@ -51,6 +51,8 @@ export type NewsItem = {
   source: string;
   date: string;
   summary?: string;
+  author?: string;
+  image?: string;
 };
 
 export async function getExternalNews(): Promise<NewsItem[]> {


### PR DESCRIPTION
## Summary
- Add "Learning and News" tagline under the Info page header
- Rework info listings into vertically spaced list with title, date, author and thumbnail
- Update article detail layout with side-by-side header and larger top image

## Testing
- `npm run build` *(fails: Missing TypeScript dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5e9cd468833184e4a5d35802164c