### PR TITLE
Reorder navigation and rename tabs

### DIFF
--- a/app/design/page.jsx
+++ b/app/design/page.jsx
@@ -103,7 +103,7 @@ export default function DesignPage() {
         </div>
       </section>
 
-      <h2 className="text-2xl font-bold">Design Work</h2>
+      <h2 className="text-2xl font-bold">Design</h2>
 
       <section className="grid md:grid-cols-2 gap-4">
         <article className="card rounded-2xl p-5"><h3 className="text-lg font-semibold">Consult & Design</h3><p className="mt-2 text-sm">We refine CAD, check tolerances, and plan for manufacturability.</p></article>

--- a/app/info/page.tsx
+++ b/app/info/page.tsx
@@ -1,12 +1,12 @@
 import InfoFilters from "../../components/InfoFilters";
 import { getExternalNews, getLocalPosts } from "../../lib/info";
 
-export default async function InfoPage() {
+export default async function KnowledgePage() {
   const localPosts = await getLocalPosts();
   const newsItems = await getExternalNews();
   return (
     <div className="max-w-7xl mx-auto px-4 py-8">
-      <h1 className="text-3xl font-bold mb-2">Info</h1>
+      <h1 className="text-3xl font-bold mb-2">Knowledge</h1>
       <p className="text-lg text-slate-300 mb-8">Learning and News</p>
       <InfoFilters localPosts={localPosts} newsItems={newsItems} />
     </div>

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -26,7 +26,7 @@ export default function HomePage() {
           </p>
           <div className="mt-6 flex gap-3">
             <Link href="/design" className="rounded-xl bubble px-4 py-2 text-sm font-semibold">Start a project</Link>
-            <Link href="/shop" className="rounded-xl bubble px-4 py-2 text-sm">Shop prints</Link>
+            <Link href="/shop" className="rounded-xl bubble px-4 py-2 text-sm">Shop items</Link>
           </div>
         </div>
 
@@ -112,8 +112,8 @@ export default function HomePage() {
             <article className="card rounded-2xl p-5">
               <h3 className="text-lg font-semibold">Popular Items</h3>
               <p className="mt-2 text-sm">
-                A growing catalog of useful parts—customizable materials and sizes in the{" "}
-                <Link href="/shop" className="underline">Shop</Link>.
+                A growing catalog of useful parts—customizable materials and sizes in{' '}
+                <Link href="/shop" className="underline">Shop Items</Link>.
               </p>
             </article>
           </div>

--- a/app/shop/page.jsx
+++ b/app/shop/page.jsx
@@ -338,7 +338,7 @@ export default function ShopPage() {
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pb-24 pt-10">
       <div className="md:flex items-end justify-between gap-4 mb-6">
         <div>
-          <h2 className="text-2xl font-bold">Shop Prints</h2>
+          <h2 className="text-2xl font-bold">Shop Items</h2>
           <p className="text-slate-200">Field-tested parts & accessories. Printed to order.</p>
         </div>
         <div className="mt-4 md:mt-0 flex gap-2">

--- a/components/Footer.jsx
+++ b/components/Footer.jsx
@@ -5,7 +5,7 @@ export default function Footer() {
         <div>© {new Date().getFullYear()} Dixon 3D</div>
         <div className="flex gap-4">
           <a href="/design" className="hover:underline">Get a quote</a>
-          <a href="/shop" className="hover:underline">Shop</a>
+          <a href="/shop" className="hover:underline">Shop Items</a>
           <a href="/" className="hover:underline">Home</a>
         </div>
         <div className="absolute left-1/2 -translate-x-1/2 text-xs text-slate-400">Enhanced with GPT-5</div>

--- a/components/Nav.jsx
+++ b/components/Nav.jsx
@@ -37,9 +37,9 @@ export default function Nav() {
 
         <nav className="hidden md:flex flex-1 items-center justify-center gap-2">
           {tab("/", "Home")}
-          {tab("/info", "Info")}
-          {tab("/design", "Design Work")}
-          {tab("/shop", "Shop Prints")}
+          {tab("/design", "Design")}
+          {tab("/shop", "Shop Items")}
+          {tab("/info", "Knowledge")}
         </nav>
 
         <div className="ml-auto flex items-center gap-2">
@@ -68,9 +68,9 @@ export default function Nav() {
             {open && (
               <div className="absolute right-0 mt-2 w-48 rounded-md bg-header/95 backdrop-blur shadow-lg ring-1 ring-black/5 p-2 flex flex-col gap-1">
                 {tab("/", "Home")}
-                {tab("/info", "Info")}
-                {tab("/design", "Design Work")}
-                {tab("/shop", "Shop Prints")}
+                {tab("/design", "Design")}
+                {tab("/shop", "Shop Items")}
+                {tab("/info", "Knowledge")}
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary
- Reorder site navigation to Home, Design, Shop Items, Knowledge
- Rename design, shop, and info pages to match new tab names
- Update footer and homepage links for Shop Items

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abd9585a2c8331a181d8722e4cc9d5