### PR TITLE
fix: upgrade Nodemailer security baseline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "dixon3d-next",
       "dependencies": {
         "next": "15.5.20",
-        "nodemailer": "^6.9.8",
+        "nodemailer": "9.0.3",
         "react": "19.2.7",
         "react-dom": "19.2.7"
       },
@@ -1389,9 +1389,9 @@
       }
     },
     "node_modules/nodemailer": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
-      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.3.tgz",
+      "integrity": "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "next": "15.5.20",
     "react": "19.2.7",
     "react-dom": "19.2.7",
-    "nodemailer": "^6.9.8"
+    "nodemailer": "9.0.3"
   },
   "devDependencies": {
     "@netlify/plugin-nextjs": "5.12.0",


### PR DESCRIPTION
## Summary

Upgrades Nodemailer to the current patched security release while preserving the existing SMTP email flow.

## Changes

- Nodemailer `6.10.1` → `9.0.3`
- Regenerates the lockfile metadata for the package update
- No source-code changes were required

## Files changed

- `package.json`
- `package-lock.json`

No SMTP environment-variable names, recipients, reply-to behavior, message contents, diagnostics, form behavior, Netlify configuration, payment code, upload code, or production settings changed.

## Verification

- `npm install` passed
- `npm ci` passed
- `npm ls --depth=0` passed and resolves `nodemailer@9.0.3`
- `npm run build` passed on Next.js `15.5.20`
- `npm audit` reports 0 vulnerabilities
- `npm audit --omit=dev` reports 0 vulnerabilities
- GET-only local checks returned HTTP 200 for `/` and `/design`
- No-network Nodemailer `streamTransport` smoke test passed
- No external SMTP connection was made
- No secrets were read or printed
- Working tree was clean and the branch was pushed without force

## Security result

Before this branch:

- 1 high-severity Nodemailer vulnerability group covering eight advisories

After this branch:

- 0 npm audit vulnerabilities

## Deployment

This is a draft PR. Do not merge without explicit approval. Merging to `main` will trigger a Netlify production deployment.